### PR TITLE
Update "PRs in the Stack" block even if it's in the middle of the body; add unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: "CI Run"
+on:
+  pull_request:
+    branches:
+      - main
+      - grok/*/*
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Test
+        run: |
+          bash tests/run.sh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cSpell.words": [
+    "printenv",
+    "pyright"
+  ]
+}

--- a/git-grok
+++ b/git-grok
@@ -18,7 +18,14 @@ from typing import Callable, Literal, TypeVar
 BRANCH_PREFIX = "grok/"
 PULL_REQUEST_HEADER = "Pull Request"
 BODY_SUFFIX_TITLE = "## PRs in the Stack"
-BODY_SUFFIX_TRAIL = "(The stack is managed by git-grok.)"
+BODY_SUFFIX_FOOTER = (
+    "(The stack is managed by [git-grok](https://github.com/DmitryKoterov/git-grok).)"
+)
+BODY_SUFFIX_RE = (
+    rf"^ {re.escape(BODY_SUFFIX_TITLE)} [^\n]* \n"
+    + r"( (\s*(\n|\Z))* (- \s* [^\n]+ (\n|\Z)) )*"
+    + r"( (\s*(\n|\Z))* [^\n]+ \bgit-grok\b [^\n]+ (\n|\Z) )?"
+)
 MAX_BRANCH_LEN_IN_PRINT = 36
 MAX_TITLE_LEN_IN_PRINT = 50
 TMP_BODY_FILE = "/tmp/git-grok.body"
@@ -336,24 +343,25 @@ class Main:
     def process_update_pr(
         self, *, prev_commit: Commit | None, commit: Commit, commits: list[Commit]
     ) -> tuple[Pr, PrUpsertResult]:
-        body_suffix: list[str] = []
+        pr_numbers: list[int] = []
+        pr_number_current: int | None = None
         for c in commits:
             assert (
                 c.url is not None
             ), f"commit {c.hash} PR URL is expected to be in the message at this point"
-            m = re.search(r"/(\d+)$", str(c.url))
+            m = re.search(r"/(\d+)$", c.url)
             if m:
-                body_suffix.append(
-                    f"- {'➡ ' if c.hash == commit.hash else ''}#{m.group(1)}"
-                )
+                pr_numbers.append(int(m.group(1)))
+                if c.hash == commit.hash:
+                    pr_number_current = int(m.group(1))
         assert (
             commit.url is not None
         ), f"commit {commit.hash} PR URL is expected to be in the message at this point"
         return self.gh_update_pr(
             url=commit.url,
             base_branch=prev_commit.branch if prev_commit else None,
-            body_suffix_title=BODY_SUFFIX_TITLE,
-            body_suffix_body="\n".join(body_suffix) + "\n\n" + BODY_SUFFIX_TRAIL,
+            pr_numbers=pr_numbers,
+            pr_number_current=pr_number_current,
         )
 
     #
@@ -450,24 +458,14 @@ class Main:
         *,
         url: str,
         base_branch: str | None,
-        body_suffix_title: str,
-        body_suffix_body: str,
+        pr_numbers: list[int],
+        pr_number_current: int | None,
     ) -> tuple[Pr, PrUpsertResult]:
         if base_branch is None:
             base_branch = self.remote_base_branch
 
         pr = self.gh_get_pr(url=url)
-        parts = re.split(
-            r"^" + re.escape(body_suffix_title) + r"[^\n]*\n",
-            pr.body,
-            flags=re.M,
-        )
-        new_body = (
-            (parts[0] if len(parts) > 1 else pr.body.rstrip() + "\n\n")
-            + body_suffix_title
-            + "\n"
-            + body_suffix_body
-        )
+        new_body = body_suffix_upsert(pr.body, pr_numbers, pr_number_current)
         if pr.base_branch == base_branch and pr.body == new_body and pr.state == "OPEN":
             return pr, "up-to-date"
 
@@ -961,6 +959,25 @@ def find_file_in_parents(file: str):
         old_path = path
         path = os.path.dirname(path)
     return None
+
+
+#
+# If there is no body suffix in the body, appends it. Otherwise, replaces the
+# previous occurrence of the body suffix (heuristically found) with the new one.
+#
+def body_suffix_upsert(
+    body: str, pr_numbers: list[int], pr_number_current: int | None
+) -> str:
+    items = [
+        f"- {'➡ ' if pr_number == pr_number_current else ''}#{pr_number}"
+        for pr_number in pr_numbers
+    ]
+    suffix = (
+        BODY_SUFFIX_TITLE + "\n" + "\n".join(items) + "\n\n" + BODY_SUFFIX_FOOTER + "\n"
+    )
+    if re.search(BODY_SUFFIX_RE, body, flags=re.M | re.I | re.X):
+        return re.sub(BODY_SUFFIX_RE, suffix, body, flags=re.M | re.I | re.X)
+    return body.rstrip() + "\n\n" + suffix
 
 
 #

--- a/tests/body_suffix_upsert_test.py
+++ b/tests/body_suffix_upsert_test.py
@@ -1,0 +1,207 @@
+__import__("sys").dont_write_bytecode = True
+import unittest
+from helpers import git_grok, dedent
+
+
+class Test(unittest.TestCase):
+    def test_idempotent(self):
+        self.assertEqual(
+            git_grok.body_suffix_upsert(
+                dedent(
+                    f"""
+                    {git_grok.BODY_SUFFIX_TITLE}
+                    - #101
+
+                    {git_grok.BODY_SUFFIX_FOOTER}
+                    """
+                ),
+                [101],
+                42,
+            ),
+            dedent(
+                f"""
+                {git_grok.BODY_SUFFIX_TITLE}
+                - #101
+
+                {git_grok.BODY_SUFFIX_FOOTER}
+                """
+            ),
+        )
+
+    def test_append(self):
+        self.assertEqual(
+            git_grok.body_suffix_upsert(
+                dedent(
+                    """
+                    Here is
+                    some text
+
+                    """
+                ),
+                [101, 42],
+                42,
+            ),
+            dedent(
+                f"""
+                Here is
+                some text
+
+                {git_grok.BODY_SUFFIX_TITLE}
+                - #101
+                - ➡ #42
+
+                {git_grok.BODY_SUFFIX_FOOTER}
+                """
+            ),
+        )
+
+    def test_update_end_and_with_empty_lines(self):
+        self.assertEqual(
+            git_grok.body_suffix_upsert(
+                dedent(
+                    """
+                    ## PRs in the Stack
+
+                    - #11
+
+                    - ➡ #22
+                    - #33
+
+                    (The stack is managed by git-grok.)
+
+                    """
+                ),
+                [101],
+                42,
+            ),
+            dedent(
+                f"""
+                {git_grok.BODY_SUFFIX_TITLE}
+                - #101
+
+                {git_grok.BODY_SUFFIX_FOOTER}
+
+                """
+            ),
+        )
+
+    def test_update_end_no_footer(self):
+        self.assertEqual(
+            git_grok.body_suffix_upsert(
+                dedent(
+                    """
+                    ## PRs in the Stack
+                    - #11
+                    - ➡ #22
+                    - #33
+                    """
+                ),
+                [101],
+                42,
+            ),
+            dedent(
+                f"""
+                {git_grok.BODY_SUFFIX_TITLE}
+                - #101
+
+                {git_grok.BODY_SUFFIX_FOOTER}
+                """
+            ),
+        )
+
+    def test_update_middle_no_footer(self):
+        self.assertEqual(
+            git_grok.body_suffix_upsert(
+                dedent(
+                    """
+                    Here is
+                    some text
+
+                    ## PRs in the Stack
+                    - #11
+                    - ➡ #22
+                    - #33
+
+                    Some other
+                    text
+                    """
+                ),
+                [101],
+                42,
+            ),
+            dedent(
+                f"""
+                Here is
+                some text
+
+                {git_grok.BODY_SUFFIX_TITLE}
+                - #101
+
+                {git_grok.BODY_SUFFIX_FOOTER}
+
+                Some other
+                text
+                """
+            ),
+        )
+
+    def test_update_middle_with_footer(self):
+        result = git_grok.body_suffix_upsert(
+            dedent(
+                f"""
+                    ## PRs in the Stack
+                    - #11
+                    
+                    - ➡ #22 something else
+                    - #33
+
+                    {git_grok.BODY_SUFFIX_FOOTER}
+                    """
+            ),
+            [101],
+            42,
+        )
+        self.assertEqual(
+            result,
+            dedent(
+                f"""
+                {git_grok.BODY_SUFFIX_TITLE}
+                - #101
+
+                {git_grok.BODY_SUFFIX_FOOTER}
+                """
+            ),
+        )
+        self.assertEqual(
+            git_grok.body_suffix_upsert(result, [101], 42),
+            result,
+        )
+
+    def test_update_no_items(self):
+        self.assertEqual(
+            git_grok.body_suffix_upsert(
+                dedent(
+                    f"""
+                    Some text
+                    ## PRs in the Stack
+                    Something else
+                    """
+                ),
+                [101],
+                42,
+            ),
+            dedent(
+                f"""
+                Some text
+                {git_grok.BODY_SUFFIX_TITLE}
+                - #101
+
+                {git_grok.BODY_SUFFIX_FOOTER}
+                Something else
+                """
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,24 @@
+import re
+import sys
+import textwrap
+from os.path import basename, dirname, realpath
+from importlib.util import spec_from_loader, module_from_spec
+from importlib.machinery import SourceFileLoader
+
+
+def import_path(path: str):
+    module_name = basename(path).replace("-", "_")
+    spec = spec_from_loader(module_name, SourceFileLoader(module_name, path))
+    assert spec
+    assert spec.loader
+    module = module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def dedent(text: str) -> str:
+    return textwrap.dedent(re.sub(r"^\n", "", text, re.S))
+
+
+git_grok = import_path(dirname(dirname(realpath(__file__))) + "/git-grok")

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd $(dirname "${BASH_SOURCE[0]}")
+
+python3 -B -m unittest discover -s . -p '*_test.py' $@


### PR DESCRIPTION
## Summary

Previously, everything after "PRs in the Stack" text in the PR description was removed, and then git-grok was addiing a new "PRs in the Stack" block. This caused problems with other tools which append their own footer to the end of the PR description (their output was erased after re-grokking).

Now, git-grok tries to find an existing "PRs in the Stack" block in the middle of the PR description (with heuristics) and, if it finds one, it replaces it with the updated text. Only if the block is not found, it's appended.

Since this logic is pretty fragile, also adding some small unit test framework to cover various usecases comprehensively.

## How was this tested?

```
tests/run.sh
git grok
```

## PRs in the Stack
- #4
- ➡ #3

(The stack is managed by [git-grok](https://github.com/DmitryKoterov/git-grok).)
