### PR TITLE
Fix typo in PR_HEADER_RE

### DIFF
--- a/git-grok
+++ b/git-grok
@@ -17,7 +17,7 @@ from typing import Callable, Literal, TypeVar
 
 BRANCH_PREFIX = "grok/"
 PR_HEADER = "Pull Request"
-PR_HEADER_RE = rf"^\s+{PR_HEADER}: (https://\S+)(?: \((.*?)\))"
+PR_HEADER_RE = rf"^\s+{PR_HEADER}: (https://\S+)(?: \((.*?)\))?"
 BODY_SUFFIX_TITLE = "## PRs in the Stack"
 BODY_SUFFIX_FOOTER = (
     "(The stack is managed by [git-grok](https://github.com/DmitryKoterov/git-grok).)"


### PR DESCRIPTION
## Summary

This typo didn't let the previously created PRs be backward compatible with the new cherry-pick-friendly behavior.

## How was this tested?

```
git commit --amend
git grok
```

## PRs in the Stack
- ➡ #8

(The stack is managed by [git-grok](https://github.com/DmitryKoterov/git-grok).)
